### PR TITLE
Unique match positions

### DIFF
--- a/lib/Babble/Match.pm
+++ b/lib/Babble/Match.pm
@@ -3,6 +3,7 @@ package Babble::Match;
 use Babble::Grammar;
 use Babble::SymbolGenerator;
 use Mu;
+use List::Util 1.45;
 use re 'eval';
 
 ro 'top_rule';
@@ -89,7 +90,9 @@ sub match_positions_of {
     /${\$self->top_re} ${wrapped}/x;
     @F;
   };
-  return @found;
+  return map { [ split ',', $_ ] }
+	  List::Util::uniqstr
+	  map { join ",", @$_ } @found;
 }
 
 sub each_match_of {

--- a/t/plugin-definedor.t
+++ b/t/plugin-definedor.t
@@ -14,6 +14,8 @@ my @cand = (
     'my $x; my $y = 3; defined($_) or $_ = $y for $x; say $x;', ],
   [ 'my $x; my $y = 3; $x //= $y if $z; say $x;',
     'my $x; my $y = 3; do { defined($_) or $_ = $y for $x } if $z; say $x;', ],
+  [ 'sub foo { return $x // 3 }',
+    'sub foo { return (map +(defined($_) ? $_ : 3), $x)[0] }', ],
 );
 
 foreach my $cand (@cand) {


### PR DESCRIPTION
This prevents running a transformation twice on the same position.

Possible fix for <https://github.com/shadow-dot-cat/Babble/pull/1>.
