### PR TITLE
Add plugins for package block and package version

### DIFF
--- a/lib/Babble/Plugin/PackageBlock.pm
+++ b/lib/Babble/Plugin/PackageBlock.pm
@@ -1,0 +1,54 @@
+package Babble::Plugin::PackageBlock;
+
+use Moo;
+
+sub transform_to_plain {
+  my ($self, $top) = @_;
+  $top->each_match_within(PackageDeclaration => [
+    [ kw => 'package' ],
+    [ meta => q{
+            (?>(?&PerlNWS)) (?>(?&PerlQualifiedIdentifier))
+        (?: (?>(?&PerlNWS)) (?&PerlVersionNumber) )?+
+    }],
+    [ ws => q{
+            (?>(?&PerlOWSOrEND))
+    }],
+    [ block =>  q{
+        (?> (?&PerlBlock) )
+    }],
+  ] => sub {
+    my ($m) = @_;
+    my ($kw, $meta,  $ws, $block) = @{$m->submatches}{ qw(kw meta ws block) };
+
+    $kw->replace_text('{ ' . $kw->text);
+    $meta->replace_text($meta->text . ';');
+    $ws->replace_text('');
+
+    my $block_text = $block->text;
+    $block_text =~ s/\A\{//;
+    $block->replace_text($block_text);
+  });
+}
+
+1;
+__END__
+
+=head1 NAME
+
+Babble::Plugin::PackageBlock - Plugin for package block syntax
+
+=head1 SYNOPSIS
+
+Converts usage of the package block syntax from
+
+    package NAMESPACE BLOCK
+
+to
+
+    { package NAMESPACE; }
+
+=head1 SEE ALSO
+
+L<package-block syntax|Syntax::Construct/package-block>
+
+=cut

--- a/lib/Babble/Plugin/PackageVersion.pm
+++ b/lib/Babble/Plugin/PackageVersion.pm
@@ -1,0 +1,72 @@
+package Babble::Plugin::PackageVersion;
+
+use Moo;
+use Data::Dumper;
+
+sub transform_to_plain {
+  my ($self, $top) = @_;
+  $top->each_match_within(PackageDeclaration => [
+    [ name => q{
+        package
+            (?>(?&PerlNWS)) (?>(?&PerlQualifiedIdentifier))
+    }],
+    [ ws => q{
+        (?>(?&PerlNWS))
+    }],
+    [ version => q{
+        (?&PerlVersionNumber)
+    }],
+    q{
+            (?>(?&PerlOWSOrEND))
+    },
+    [ rest => q[
+            (?> ; | (?&PerlBlock) | (?= \} | \z ))
+    ]],
+  ] => sub {
+    my ($m) = @_;
+    my $gr = $m->grammar_regexp;
+
+    my ($name, $ws, $version, $rest) =
+      @{$m->submatches}{ qw(name ws version rest) };
+
+    $ws->replace_text('');
+
+    my $version_info = do {
+      local $Data::Dumper::Terse = 1;
+      local $Data::Dumper::Indent = 0;
+      Dumper($version->text);
+    };
+    my $version_statement = q{our $VERSION = }.$version_info.';';
+    $version->replace_text('');
+
+    if( $rest->text =~ /\A\{/ ) {
+      $rest->transform_text(sub { s/\A \{ (?&PerlOWS) $gr/{\n${version_statement}\n/x });
+    } else {
+      $rest->transform_text(sub { s/\A ;? /;\n${version_statement}\n/x });
+    }
+  });
+}
+
+1;
+__END__
+
+=head1 NAME
+
+Babble::Plugin::PackageVersion - Plugin for package version syntax
+
+=head1 SYNOPSIS
+
+Converts usage of the package version syntax from
+
+    package NAMESPACE VERSION
+
+to
+
+    package NAMESPACE;
+    $NAMESPACE::VERSION = VERSION;
+
+=head1 SEE ALSO
+
+L<package-version syntax|Syntax::Construct/package-version>
+
+=cut

--- a/t/plugin-packageblock.t
+++ b/t/plugin-packageblock.t
@@ -1,0 +1,22 @@
+use strictures 2;
+use Test::More;
+use Babble::Plugin::PackageBlock;
+use Babble::Match;
+
+my $pb = Babble::Plugin::PackageBlock->new;
+
+my @cand = (
+  [ 'package Foo::Bar { 42 }',
+    '{ package Foo::Bar; 42 }', ],
+  [ 'package Foo::Bar v1.2.3 { 42 }',
+    '{ package Foo::Bar v1.2.3; 42 }', ],
+);
+
+foreach my $cand (@cand) {
+  my ($from, $to) = @$cand;
+  my $top = Babble::Match->new(top_rule => 'Document', text => $from);
+  $pb->transform_to_plain($top);
+  is($top->text, $to, "${from}");
+}
+
+done_testing;

--- a/t/plugin-packageversion.t
+++ b/t/plugin-packageversion.t
@@ -1,0 +1,82 @@
+use strictures 2;
+use Test::More;
+use Babble::Plugin::PackageVersion;
+use Babble::Match;
+
+my $pv = Babble::Plugin::PackageVersion->new;
+
+my @cand = (
+  # no version, no change
+  [ 'package Foo::Bar { 42 }',
+    'package Foo::Bar { 42 }', ],
+  [ 'package Foo::Bar; 42',
+    'package Foo::Bar; 42', ],
+
+  # statement - v-string
+  [ 'package Foo::Bar v1.2.3;
+42',
+    q{package Foo::Bar;
+our $VERSION = 'v1.2.3';
+
+42}, ],
+
+  # statement - decimal
+  [ 'package Foo::Bar 1.30;
+42',
+    q{package Foo::Bar;
+our $VERSION = '1.30';
+
+42}, ],
+
+  # block - v-string
+  [ 'package Foo::Bar v1.2.3 { 42 }',
+    q{package Foo::Bar {
+our $VERSION = 'v1.2.3';
+42 }}, ],
+
+  # block - decimal
+  [ 'package Foo::Bar 1.30 { 42 }',
+    q{package Foo::Bar {
+our $VERSION = '1.30';
+42 }}, ],
+
+  # single statement (no ;)
+  [ 'package Foo::Bar v1.2.3',
+    q{package Foo::Bar;
+our $VERSION = 'v1.2.3';
+}, ],
+
+  # single statement in block (with ;)
+  [ '{package Foo::Bar 1.30;}',
+    q{{package Foo::Bar;
+our $VERSION = '1.30';
+}}, ],
+  [ '{package Foo::Bar 1.30; 42}',
+    q{{package Foo::Bar;
+our $VERSION = '1.30';
+ 42}}, ],
+
+  # single statment in block (no ;)
+  #
+  # This fails because the PPR grammar considers the whole code a PerlStatement
+  # and this matches the
+  #
+  #   Inlined (?&PerlPackageDeclaration)
+  #
+  # part of the grammar.
+  #
+  # It may be such a small edge case that it might not be worth supporting.
+  ( [ '{package Foo::Bar 1.30}',
+    q{{package Foo::Bar;
+our $VERSION = '1.30';
+}}, ] )x(0),# removes this specific test case
+);
+
+foreach my $cand (@cand) {
+  my ($from, $to) = @$cand;
+  my $top = Babble::Match->new(top_rule => 'Document', text => $from);
+  $pv->transform_to_plain($top);
+  is($top->text, $to, "${from}");
+}
+
+done_testing;


### PR DESCRIPTION
Fixes <https://github.com/shadow-dot-cat/Babble/issues/9>.

---

Seems that the only difference between running both in a different order is a
small amount of white-space:

```shell
$ perl -I lib -MBabble::Filter=::PackageBlock,::PackageVersion -0777 -pe  babble <(echo 'package Foo::Bar v1.2.3 { 42 }')
{ package Foo::Bar;
our $VERSION = 'v1.2.3';
 42 }
$ perl -I lib -MBabble::Filter=::PackageVersion,::PackageBlock -0777 -pe  babble <(echo 'package Foo::Bar v1.2.3 { 42 }')
{ package Foo::Bar;
our $VERSION = 'v1.2.3';
42 }
```

I'm debating whether to use a flag to place `$VERSION` on its own line or not.
And I can also see a flag for using version objects or not.
