### PR TITLE
Update use of PerlTerm for PPR ≥ v0.001000

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,5 @@
 requires strictures => 2;
 requires Moo => 2;
-requires PPR => '0.000021';
+requires PPR => '0.001004';
 requires Mu => 0;
 requires 'Module::Runtime' => 0;

--- a/lib/Babble/Plugin/PostfixDeref.pm
+++ b/lib/Babble/Plugin/PostfixDeref.pm
@@ -126,10 +126,6 @@ sub transform_to_plain {
     [ term => "(?> $term_derefable )" ],
     [ postfix => '(?&PerlTermPostfixDereference)' ],
   ] => $tf);
-  $top->each_match_within(ScalarAccess => [
-    [ term => '(?>(?&PerlVariableScalar))' ],
-    [ postfix => $scalar_post ],
-  ] => $tf);
 }
 
 1;

--- a/lib/Babble/Plugin/PostfixDeref.pm
+++ b/lib/Babble/Plugin/PostfixDeref.pm
@@ -2,6 +2,63 @@ package Babble::Plugin::PostfixDeref;
 
 use Moo;
 
+my $term_derefable = q{
+            # Copied from <PerlTerm> rule in PPR::X@0.001002
+            # The remaining alternatives can all take postfix dereferencers...
+            # ...
+              (?:
+                    (?= \$ )  (?&PerlScalarAccess)
+              |
+                    (?= \@ )  (?&PerlArrayAccess)
+              |
+                    (?=  % )  (?&PerlHashAccess)
+              |
+                    (?&PerlAnonymousSubroutine)
+              |
+                    (?>(?&PerlNullaryBuiltinFunction))  (?! (?>(?&PerlOWS)) \( )
+              |
+                    (?&PerlDoBlock) | (?&PerlEvalBlock)
+              |
+                    (?&PerlCall)
+              |
+                    (?&PerlVariableDeclaration)
+              |
+                    (?&PerlTypeglob)
+              |
+                    (?>(?&PerlParenthesesList))
+
+                    # Can optionally do a [...] lookup straight after the parens,
+                    # followd by any number of other look-ups
+                    (?:
+                        (?>(?&PerlOWS)) (?&PerlArrayIndexer)
+                        (?:
+                            (?>(?&PerlOWS))
+                            (?>
+                                (?&PerlArrayIndexer)
+                            |   (?&PerlHashIndexer)
+                            |   (?&PerlParenthesesList)
+                            )
+                        )*+
+                    )?+
+              |
+                    (?&PerlAnonymousArray)
+              |
+                    (?&PerlAnonymousHash)
+              |
+                    (?&PerlDiamondOperator)
+              |
+                    (?&PerlContextualMatch)
+              |
+                    (?&PerlQuotelikeS)
+              |
+                    (?&PerlQuotelikeTR)
+              |
+                    (?&PerlQuotelikeQX)
+              |
+                    (?&PerlLiteral)
+              )
+};
+
 my $scalar_post = q{
   (?:
     (?>(?&PerlOWS))
@@ -65,11 +122,9 @@ sub transform_to_plain {
     $m->submatches->{term}->replace_text($term);
     $m->submatches->{postfix}->replace_text('');
   };
-  $top->each_match_within(PrefixPostfixTerm => [
-    '(?: (?>(?&PerlPrefixUnaryOperator))  (?&PerlOWS) )*+',
-    [ term => '(?>(?&PerlTerm))' ],
+  $top->each_match_within(Term => [
+    [ term => "(?> $term_derefable )" ],
     [ postfix => '(?&PerlTermPostfixDereference)' ],
-    '(?: (?>(?&PerlOWS)) (?&PerlPostfixUnaryOperator) )?+'
   ] => $tf);
   $top->each_match_within(ScalarAccess => [
     [ term => '(?>(?&PerlVariableScalar))' ],

--- a/t/plugin-postfixderef.t
+++ b/t/plugin-postfixderef.t
@@ -12,6 +12,10 @@ my @cand = (
     'my $x = (map @{$_}, ((map $$_, $foo->bar)[0])->baz);' ],
   [ 'my @val = $foo->@{qw(key names)};',
     'my @val = (map @{$_}{qw(key names)}, $foo);' ],
+  [ 'my $val = $foo[0];',
+    'my $val = $foo[0];' ],
+  [ 'my $val = $foo[$idx];',
+    'my $val = $foo[$idx];' ],
 );
 
 foreach my $cand (@cand) {


### PR DESCRIPTION
With the release of PPR v0.001000 there is a backwards incompatible
change in the definition of the `PerlTerm` rule to include postfix
arrows for dereferencing and methods.

This affects the plugin(s):

```sh
    $ git grep -lP '\b(Perl)?(Term|((ScalarAccess|ArrayAccess)(NoSpace)?))' lib/
    lib/Babble/Plugin/PostfixDeref.pm
```
